### PR TITLE
Add Docker support for web and api codebases using docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+**/node_modules
+**/.cache

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:12.8.1-alpine
+
+ENV APP_DIR=/usr/local/app/
+RUN mkdir -p $APP_DIR
+WORKDIR $APP_DIR
+
+# Expose api port
+EXPOSE 3000
+
+# Update image packages
+RUN apk update
+
+# Add repo to directory
+ADD . $APP_DIR
+
+# Install node modules
+RUN npm install
+
+CMD npm start
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  mongodb:
+    image: "mongo"
+    ports:
+      - "27017:27017"
+  api:
+    build: ./api/
+    environment:
+      - MONGO_URL=mongodb://mongodb:27017/fakedb
+      - PORT=3000
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./api:/usr/src/app
+    depends_on:
+      - mongodb
+  web:
+    build: ./web/
+    environment:
+      - API_URL=http://localhost:3000
+    ports:
+      - "1234:1234"
+    volumes:
+      - ./web:/usr/src/app
+    depends_on:
+      - api

--- a/web/.babelrc
+++ b/web/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    ["@babel/transform-runtime"]
+  ]
+}

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.cache

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:12.8.1-alpine
+
+ENV APP_DIR=/usr/local/app
+RUN mkdir -p $APP_DIR
+WORKDIR $APP_DIR
+
+# Expose web port
+EXPOSE 1234
+
+# Update image packages
+RUN apk update
+
+# Add repo to directory
+ADD . $APP_DIR
+
+# Install node modules
+RUN npm install
+
+CMD npm start

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1007,9 +1007,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-      "integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
+      "integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -1128,12 +1128,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
-      "dev": true,
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -5581,6 +5580,21 @@
               "dev": true
             }
           }
+        },
+        "@babel/runtime": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
+          "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
         }
       }
     },
@@ -6408,10 +6422,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "@babel/plugin-transform-runtime": "^7.5.5",
+    "@babel/plugin-transform-runtime": "^7.6.0",
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
     "parcel-bundler": "^1.12.3",
@@ -20,6 +20,7 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
+    "@babel/runtime": "^7.6.0",
     "normalize.css": "^8.0.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
1. Added a Dockerfile for both the api and ui codebases
2. Added a docker-compose.yml file

Note: Had to install `@babel/runtime` in order for the UI to run correctly. Not sure if that was part of the assignment, but I thought I'd let you guys know. I'm sure there might've been other ways to make it work without installing an extra dependency and upgrading `@babel/plugin-transform-runtime` but that was the quickest fix. Also, this is a burner GitHub account which is why there is no picture or history, I use my personal one at my current workplace and didn't want it to show up.